### PR TITLE
Cloud provider read only variables

### DIFF
--- a/kubehub/models/cloud_provider.py
+++ b/kubehub/models/cloud_provider.py
@@ -1,16 +1,21 @@
 from django.db import models
+import subprocess
 
 
 class CloudProvider(models.Model):
+    name_max = int(subprocess.check_output("getconf NAME_MAX /", shell=True))
     CP_TYPES = (
         ('Proxmox', 'Proxmox'),
         ('AWS', 'AWS'),
         ('GCP', 'GCP')
     )
-    cp_type = models.CharField(max_length=20, choices=CP_TYPES)
-    name = models.CharField(max_length=50)
-    api_endpoint = models.CharField(max_length=50)
-    password = models.CharField(max_length=20)
+    cp_type = models.CharField(max_length=name_max, choices=CP_TYPES)
+    name = models.CharField(max_length=name_max)
+    api_endpoint = models.CharField(max_length=name_max)
+    password = models.CharField(max_length=name_max)
+    readonly_fields = ('cp_type', 'api_endpoint', 'password')
+
 
     def __str__(self):
-        return f'cloud_provider_id: {self.id}, name: {self.name}, api_endpoint: {self.api_endpoint}, password: {self.password}'
+        return f'cloud_provider_id: {self.id}, name: {self.name}, api_endpoint: {self.api_endpoint}, ' \
+               f'password: {self.password}'

--- a/kubehub/serializers/cloud_provider_serializer.py
+++ b/kubehub/serializers/cloud_provider_serializer.py
@@ -12,10 +12,7 @@ class CloudProviderSerializer(serializers.ModelSerializer):
         return cloud_provider
 
     def update(self, instance, validated_data):
-        instance.cp_type = validated_data.get('cp_type', instance.cp_type)
         instance.name = validated_data.get('name', instance.name)
-        instance.api_endpoint = validated_data.get('api_endpoint', instance.api_endpoint)
-        instance.password = validated_data.get('password', instance.password)
         instance.save()
 
         return instance


### PR DESCRIPTION
- changed max length 'cp_type', 'api_endpoint', 'password' added to read only_fields
- removed ability to edit 'cp_type', 'api_endpoint', 'password' fields